### PR TITLE
Android: Sample image if large (>5MB) to prevent crash on upload of large images

### DIFF
--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -579,6 +579,25 @@ public class ImagePickerModule extends ReactContextBaseJavaModule {
     return Base64.encodeToString(bytes, Base64.NO_WRAP);
   }
 
+    /**
+   * If necessary, set a sample size > 1 to request the decoder to subsample the
+   * original image, returning a smaller image to save memory.
+   */
+  private int getSampleSize(final String realPath) {
+    File file = new File(realPath);
+    int maxMB = 5;
+    long maxByte = maxMB * 1024 * 1024;
+    long length = file.length();
+    int sampleSize = 1;
+
+    while (length > maxByte) {
+      length /= 2;
+      sampleSize *= 2;
+    }
+
+    return sampleSize;
+  }
+
   /**
    * Create a resized image to fulfill the maxWidth/maxHeight, quality and rotation values
    *
@@ -590,6 +609,8 @@ public class ImagePickerModule extends ReactContextBaseJavaModule {
   private File getResizedImage(final String realPath, final int initialWidth, final int initialHeight) {
     Options options = new BitmapFactory.Options();
     options.inScaled = false;
+    options.inSampleSize = getSampleSize(realPath);
+
     Bitmap photo = BitmapFactory.decodeFile(realPath, options);
 
     if (photo == null) {


### PR DESCRIPTION
I had an issue where my Android users were getting crashes because the uploaded images were too large. Since Android apps are limited to 16MB of RAM usage, loading a large image from library can cause this limit to be exceeded and crash the app.

What this PR does is simply use the BitmapFactory option "inSampleSize" to sample the image if it exceeds 5MB. This is by no means an optimal solution, because I don't actually measure the memory usage of the app, but in my case 5MB is sufficiently large for it to be sampled down without noticing any quality differences.

Please suggest how I can improve this PR if needed, it solved my problem so I'm currently using my fork in my app.