### PR TITLE
[Android] Subsample image to save memory.

### DIFF
--- a/android/src/main/java/com/imagepicker/utils/MediaUtils.java
+++ b/android/src/main/java/com/imagepicker/utils/MediaUtils.java
@@ -79,13 +79,23 @@ public class MediaUtils
     public static @NonNull ImageConfig getResizedImage(@NonNull final Context context,
                                                        @NonNull final ReadableMap options,
                                                        @NonNull final ImageConfig imageConfig,
-                                                       final int initialWidth,
-                                                       final int initialHeight,
+                                                       int initialWidth,
+                                                       int initialHeight,
                                                        final int requestCode)
     {
         BitmapFactory.Options imageOptions = new BitmapFactory.Options();
         imageOptions.inScaled = false;
-        // FIXME: OOM here
+        imageOptions.inSampleSize = 1;
+
+        if (imageConfig.maxWidth != 0 || imageConfig.maxHeight != 0) {
+            while ((imageConfig.maxWidth == 0 || initialWidth > 2 * imageConfig.maxWidth) &&
+                   (imageConfig.maxHeight == 0 || initialHeight > 2 * imageConfig.maxHeight)) {
+                imageOptions.inSampleSize *= 2;
+                initialHeight /= 2;
+                initialWidth /= 2;
+            }
+        }
+
         Bitmap photo = BitmapFactory.decodeFile(imageConfig.original.getAbsolutePath(), imageOptions);
 
         if (photo == null)


### PR DESCRIPTION
## Motivation (required)

This PR addresses the issue in https://github.com/react-community/react-native-image-picker/pull/428. If original image is big then Android device may run out of memory. The solution is to use subsampling if target maxWidth and maxHeight is much smaller than original. There is a side effect. If original can fit in memory, then using subsampling may cause lower image quality in resized version. I can add another check and only use subsampling when original is very big. But it's difficult to figure out what size will cause problems. I was able to load images >24M on a Galaxy S3 emulator. But others had trouble with smaller sizes.

## Test Plan (required)

Tested on Galaxy S3 emulator.