### PR TITLE
Avoid conflicting with other FileProviders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ yarn.lock
 
 ## Android iml
 *.iml
+
+.vscode/

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
   >
     <application>
       <provider
-            android:name="android.support.v4.content.FileProvider"
+            android:name="com.imagepicker.FileProvider"
             android:authorities="${applicationId}.provider"
             android:exported="false"
             android:grantUriPermissions="true">

--- a/android/src/main/java/com/imagepicker/FileProvider.java
+++ b/android/src/main/java/com/imagepicker/FileProvider.java
@@ -1,0 +1,4 @@
+package com.imagepicker;
+
+public class FileProvider extends android.support.v4.content.FileProvider {
+}


### PR DESCRIPTION
If multiple AndroidManifest.xml files specify FileProviders (e.g. the app, a library like react-native-image-picker), you may receive compilation errors when these AndroidManifest.xml files are merged due to conflicts in fields such as `android:authorities` and `android:resource`.

This occurs when multiple AndroidManifest.xml files specify a `android.support.v4.content.FileProvider`. To avoid the conflict, we subclass `android.support.v4.content.FileProvider` and then we refer to our subclass in the AndroidManifest.xml file to avoid the conflict.

This solution is described here: http://stackoverflow.com/a/41550634

I think this might be related to some of the discussion in #485.

Also, I added .vscode/ to .gitignore.

Adam Comella
Microsoft Corp.