### PR TITLE
null checker for some old phones

### DIFF
--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -250,7 +250,12 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
       final File original = createNewFile(reactContext, this.options, false);
       imageConfig = imageConfig.withOriginalFile(original);
 
-      cameraCaptureURI = RealPathUtil.compatUriFromFile(reactContext, imageConfig.original);
+      if (imageConfig.original != null) {
+        cameraCaptureURI = RealPathUtil.compatUriFromFile(reactContext, imageConfig.original);
+      }else {
+        responseHelper.invokeError(callback, "Couldn't get file path for photo");
+        return;
+      }
       if (cameraCaptureURI == null)
       {
         responseHelper.invokeError(callback, "Couldn't get file path for photo");


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [ ] Match the **code formatting** of the rest of the codebase.
- [ ] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)

What existing problem does the pull request solve?
some old phone do have this null issue when connect it's storage to a computer.

## Test Plan (required)
when connect it's storage to a computer.
the adb outputs:
java.lang.NullPointerException: file
	at android.net.Uri.fromFile(Uri.java)
	at com.imagepicker.utils.RealPathUtil.compatUriFromFile(RealPathUtil.java:25)
	at com.imagepicker.ImagePickerModule.launchCamera(ImagePickerModule.java:253)
	at com.imagepicker.ImagePickerModule.launchCamera(ImagePickerModule.java:203)
...

after null check the code works fine.
