### PR TITLE
disable permission dialog when permissionDenied=null

### DIFF
--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -570,7 +570,9 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
                     innerActivity.startActivityForResult(intent, 1);
                   }
                 });
-        dialog.show();
+        if (dialog != null) {
+          dialog.show();
+        }
         return false;
       }
       else

--- a/android/src/main/java/com/imagepicker/permissions/PermissionUtils.java
+++ b/android/src/main/java/com/imagepicker/permissions/PermissionUtils.java
@@ -7,10 +7,12 @@ import android.support.annotation.Nullable;
 import android.support.v7.app.AlertDialog;
 
 import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.ReadableNativeMap;
 import com.imagepicker.ImagePickerModule;
 import com.imagepicker.R;
 
 import java.lang.ref.WeakReference;
+import java.util.HashMap;
 
 /**
  * Created by rusfearuth on 03.03.17.
@@ -26,7 +28,16 @@ public class PermissionUtils
         {
             return null;
         }
+        if (!options.hasKey("permissionDenied"))
+        {
+            return null;
+        }
         final ReadableMap permissionDenied = options.getMap("permissionDenied");
+        if (((ReadableNativeMap) permissionDenied).toHashMap().size()  == 0)
+        {
+            return null;
+        }
+
         final String title = permissionDenied.getString("title");
         final String text = permissionDenied.getString("text");
         final String btnReTryTitle = permissionDenied.getString("reTryTitle");


### PR DESCRIPTION
**motivation**

I don't want to use `permissionDenied` option because
- I can't customize dialog styles (we have custom)
- back button doesn't work on this dialog
- no ios support 

And now I can't disable it
 
**test plan**

add here https://github.com/react-community/react-native-image-picker/blob/develop/Example/App.js#L28
`permissionDenied: null`

previous behaviour - app crashes
current behaviour - nothing is happening

