### PR TITLE
Remove deprecated method for RN 0.47 compat

### DIFF
--- a/android/src/main/java/com/imagepicker/ImagePickerPackage.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerPackage.java
@@ -32,11 +32,6 @@ public class ImagePickerPackage implements ReactPackage {
   }
 
   @Override
-  public List<Class<? extends JavaScriptModule>> createJSModules() {
-    return Collections.emptyList();
-  }
-
-  @Override
   public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
     return Collections.emptyList();
   }


### PR DESCRIPTION
## Motivation (required)

The component doesn't compile in RN 0.47-rc5 - discussion at https://github.com/facebook/react-native/issues/15232

## Test Plan 

Upgrade any project that uses this component to RN 0.47
