### PR TITLE
Fixed an error while launching ImagePicker on android emulator 7.0 x8…

### DIFF
--- a/android/src/main/java/com/imagepicker/media/ImageConfig.java
+++ b/android/src/main/java/com/imagepicker/media/ImageConfig.java
@@ -107,12 +107,12 @@ public class ImageConfig
         int maxWidth = 0;
         if (options.hasKey("maxWidth"))
         {
-            maxWidth = options.getInt("maxWidth");
+            maxWidth = (int) (options.getDouble("maxWidth"));
         }
         int maxHeight = 0;
         if (options.hasKey("maxHeight"))
         {
-            maxHeight = options.getInt("maxHeight");
+            maxHeight = (int) (options.getDouble("maxHeight"));
         }
         int quality = 100;
         if (options.hasKey("quality"))
@@ -122,7 +122,7 @@ public class ImageConfig
         int rotation = 0;
         if (options.hasKey("rotation"))
         {
-            rotation = options.getInt("rotation");
+            rotation = (int) (options.getDouble("rotation"));
         }
         boolean saveToCameraRoll = false;
         if (options.hasKey("storageOptions"))


### PR DESCRIPTION
## Motivation (required)

I was trying to test my RN App on an android x86 Emulator. My App crashed as soon as I selected Image from Gallery. Following is the error from adb logcat
![image](https://user-images.githubusercontent.com/1473945/28810762-6911072a-7659-11e7-914e-042e42682035.png)

I have also experienced this crash on a real android device too.

## Test Plan (required)
1. Pick Image from Gallery
    a. Launch App
    b. Select Image from Gallery Option
    c. Able to select Image from Gallery
    d. Test Case passed

2. Take picture from Camera
   a. Launch App
   b. Select Image from Camera
   c. Take picture using camera
   d. Test case passed
