### PR TITLE
Remove createJSModules @overide marker - RN 0.47 compatibility

### DIFF
--- a/android/src/main/java/com/imagepicker/ImagePickerPackage.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerPackage.java
@@ -30,7 +30,8 @@ public class ImagePickerPackage implements ReactPackage {
   public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
     return Arrays.<NativeModule>asList(new ImagePickerModule(reactContext, dialogThemeId));
   }
-
+  
+  // Deprecated RN 0.47
   public List<Class<? extends JavaScriptModule>> createJSModules() {
     return Collections.emptyList();
   }

--- a/android/src/main/java/com/imagepicker/ImagePickerPackage.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerPackage.java
@@ -30,7 +30,7 @@ public class ImagePickerPackage implements ReactPackage {
   public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
     return Arrays.<NativeModule>asList(new ImagePickerModule(reactContext, dialogThemeId));
   }
-  
+
   // Deprecated RN 0.47
   public List<Class<? extends JavaScriptModule>> createJSModules() {
     return Collections.emptyList();

--- a/android/src/main/java/com/imagepicker/ImagePickerPackage.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerPackage.java
@@ -31,7 +31,6 @@ public class ImagePickerPackage implements ReactPackage {
     return Arrays.<NativeModule>asList(new ImagePickerModule(reactContext, dialogThemeId));
   }
 
-  @Override
   public List<Class<? extends JavaScriptModule>> createJSModules() {
     return Collections.emptyList();
   }


### PR DESCRIPTION
## Motivation (required)

[`createJSModules` is now not required on Android](https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8) from RN 0.47. I actually can't build an app on RN 0.47 without removing this method/@ovveride marker. There is similar PR (#649), but this one seems to be better for backwards compatibility.
