### PR TITLE
Update documentation for storageOptions.waitUntilSaved

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ storageOptions | OK | OK | If this key is provided, the image will be saved in y
 storageOptions.skipBackup | OK | - | If true, the photo will NOT be backed up to iCloud
 storageOptions.path | OK | - | If set, will save the image at `Documents/[path]/` rather than the root `Documents`
 storageOptions.cameraRoll | OK | OK | If true, the cropped photo will be saved to the iOS Camera Roll or Android DCIM folder.
-storageOptions.waitUntilSaved | OK | - | If true, will delay the response callback until after the photo/video was saved to the Camera Roll. If the photo or video was just taken, then the file name and timestamp fields are only provided in the response object when this is true.
+storageOptions.waitUntilSaved | OK | - | If true, will delay the response callback until after the photo/video was saved to the Camera Roll. If the photo or video was just taken, then the file name and timestamp fields are only provided in the response object when this AND `cameraRoll` are both true.
 permissionDenied.title | - | OK | Title of explaining permissions dialog. By default `Permission denied`.
 permissionDenied.text | - | OK | Message of explaining permissions dialog. By default `To be able to take pictures with your camera and choose images from your library.`.
 permissionDenied.reTryTitle | - | OK | Title of re-try button. By default `re-try`


### PR DESCRIPTION
## Motivation (required)

I was experiencing errors when trying to use a freshly taken photo due to `fileName` being undefined even when `storageOptions.waitUntilSaved` set to `true`. Then I came across the original PR #394 for this functionality which states that both `cameraRoll` AND `waitUntilSaved` need to be `true` for `fileName` and `timestamp` to be available for captured media.

This PR is a small change to the README to make this information easier to find for others, as I noticed issues such as #576.