### PR TITLE
Android to pick from document picker instead of camera library

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,4 @@
-* Fixedse read the following carefully before opening a new issue.
+* Please read the following carefully before opening a new issue.
 Your issue may be closed if it does not provide the information required by this template.
 
 --- Delete everything above this line ---

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# React Native Image Picker [![npm version](https://badge.fury.io/js/react-native-image-picker.svg)](https://badge.fury.io/js/react-native-image-picker) [![npm](https://img.shields.io/npm/dt/react-native-image-picker.svg)](https://www.npmjs.org/package/react-native-image-picker) ![MIT](https://img.shields.io/dub/l/vibe-d.svg) ![Platform - Android and iOS](https://img.shields.io/badge/platform-Android%20%7C%20iOS-yellow.svg)
+# React Native Image Picker [![npm version](https://badge.fury.io/js/react-native-image-picker.svg)](https://badge.fury.io/js/react-native-image-picker) [![npm](https://img.shields.io/npm/dt/react-native-image-picker.svg)](https://www.npmjs.org/package/react-native-image-picker) ![MIT](https://img.shields.io/dub/l/vibe-d.svg) ![Platform - Android and iOS](https://img.shields.io/badge/platform-Android%20%7C%20iOS-yellow.svg) [![Gitter chat](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/react-native-image-picker/Lobby)
 
 A React Native module that allows you to use native UI to select a photo/video from the device library or directly from the camera, like so:
 

--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -306,14 +306,21 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
     if (pickVideo)
     {
       requestCode = REQUEST_LAUNCH_VIDEO_LIBRARY;
-      libraryIntent = new Intent(Intent.ACTION_PICK);
+      if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.KITKAT) {
+        libraryIntent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
+      } else {
+        libraryIntent = new Intent(Intent.ACTION_PICK);
+      }
       libraryIntent.setType("video/*");
     }
     else
     {
       requestCode = REQUEST_LAUNCH_IMAGE_LIBRARY;
-      libraryIntent = new Intent(Intent.ACTION_PICK,
-      MediaStore.Images.Media.EXTERNAL_CONTENT_URI);
+      if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.KITKAT) {
+        libraryIntent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
+      } else {
+        libraryIntent = new Intent(Intent.ACTION_PICK, MediaStore.Images.Media.EXTERNAL_CONTENT_URI);
+      }
     }
 
     if (libraryIntent.resolveActivity(reactContext.getPackageManager()) == null)

--- a/android/src/main/java/com/imagepicker/ImagePickerPackage.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerPackage.java
@@ -31,7 +31,7 @@ public class ImagePickerPackage implements ReactPackage {
     return Arrays.<NativeModule>asList(new ImagePickerModule(reactContext, dialogThemeId));
   }
 
-  @Override
+  // Deprecated RN 0.47
   public List<Class<? extends JavaScriptModule>> createJSModules() {
     return Collections.emptyList();
   }

--- a/android/src/main/java/com/imagepicker/utils/MediaUtils.java
+++ b/android/src/main/java/com/imagepicker/utils/MediaUtils.java
@@ -79,13 +79,23 @@ public class MediaUtils
     public static @NonNull ImageConfig getResizedImage(@NonNull final Context context,
                                                        @NonNull final ReadableMap options,
                                                        @NonNull final ImageConfig imageConfig,
-                                                       final int initialWidth,
-                                                       final int initialHeight,
+                                                       int initialWidth,
+                                                       int initialHeight,
                                                        final int requestCode)
     {
         BitmapFactory.Options imageOptions = new BitmapFactory.Options();
         imageOptions.inScaled = false;
-        // FIXME: OOM here
+        imageOptions.inSampleSize = 1;
+
+        if (imageConfig.maxWidth != 0 || imageConfig.maxHeight != 0) {
+            while ((imageConfig.maxWidth == 0 || initialWidth > 2 * imageConfig.maxWidth) &&
+                   (imageConfig.maxHeight == 0 || initialHeight > 2 * imageConfig.maxHeight)) {
+                imageOptions.inSampleSize *= 2;
+                initialHeight /= 2;
+                initialWidth /= 2;
+            }
+        }
+
         Bitmap photo = BitmapFactory.decodeFile(imageConfig.original.getAbsolutePath(), imageOptions);
 
         if (photo == null)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-image-picker",
   "description": "A React Native module that allows you to use native UI to select media from the device library or directly from the camera",
-  "version": "0.26.2",
+  "version": "0.26.3",
   "main": "index.js",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "picker"
   ],
   "scripts": {
-    "prepublish": "rm -rf android/build Example/android/build Example/android/app/build node_modules"
+    "prepare": "rm -rf android/build Example/android/build Example/android/app/build node_modules"
   },
   "types": "./index.d.ts"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-image-picker",
   "description": "A React Native module that allows you to use native UI to select media from the device library or directly from the camera",
-  "version": "0.26.3",
+  "version": "0.26.4",
   "main": "index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)

What existing problem does the pull request solve?
Image picker only picks from camera library using ACTION_PICK intent. We change to ACTION_OPEN_DOCUMENT to pick photos and videos in other phone directories.

## Test Plan (required)

1. Use 
```
ImagePicker.launchImageLibrary(options, async (data) => {
        console.log(data);
});
```

2. A document library picker should open instead of camera image picker
