### PR TITLE
Avoid copying image data when saving and close the stream!

### DIFF
--- a/android/src/main/java/com/imagepicker/utils/MediaUtils.java
+++ b/android/src/main/java/com/imagepicker/utils/MediaUtils.java
@@ -175,11 +175,9 @@ public class MediaUtils
 
         result = result.withResizedFile(resized);
 
-        FileOutputStream fos;
-        try
+        try (FileOutputStream fos = new FileOutputStream(result.resized))
         {
-            fos = new FileOutputStream(result.resized);
-            fos.write(bytes.toByteArray());
+            bytes.writeTo(fos);
         }
         catch (IOException e)
         {


### PR DESCRIPTION
Instead of duplicating the entire image in memory with
ByteArrayOutputStream.toByteArray(), write to the FileOutputStream without copying.

## Motivation (required)
getResizedImage() often fails with OOME for larger images. See this stacktrace:
```
D/ERROR   ( 1993): java.lang.OutOfMemoryError: Failed to allocate a 5861516 byte allocation with 4274626 free bytes and 4MB until OOM
D/ERROR   ( 1993):      at java.io.ByteArrayOutputStream.toByteArray(ByteArrayOutputStream.java:122)
D/ERROR   ( 1993):      at com.imagepicker.utils.MediaUtils.getResizedImage(MediaUtils.java:182)
D/ERROR   ( 1993):      at com.imagepicker.ImagePickerModule.onActivityResult(ImagePickerModule.java:453)
D/ERROR   ( 1993):      at com.facebook.react.bridge.ReactContext.onActivityResult(ReactContext.java:256)
D/ERROR   ( 1993):      at com.facebook.react.ReactInstanceManager.onActivityResult(ReactInstanceManager.java:656)
D/ERROR   ( 1993):      at com.reactnativenavigation.react.NavigationReactGateway.onActivityResult(NavigationReactGateway.java:94)
D/ERROR   ( 1993):      at com.reactnativenavigation.controllers.NavigationActivity.onActivityResult(NavigationActivity.java:187)
D/ERROR   ( 1993):      at android.app.Activity.dispatchActivityResult(Activity.java:6226)
D/ERROR   ( 1993):      at android.app.ActivityThread.deliverResults(ActivityThread.java:3642)
D/ERROR   ( 1993):      at android.app.ActivityThread.handleSendResult(ActivityThread.java:3689)
D/ERROR   ( 1993):      at android.app.ActivityThread.access$1300(ActivityThread.java:151)
D/ERROR   ( 1993):      at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1362)
D/ERROR   ( 1993):      at android.os.Handler.dispatchMessage(Handler.java:102)
D/ERROR   ( 1993):      at android.os.Looper.loop(Looper.java:135)
D/ERROR   ( 1993):      at android.app.ActivityThread.main(ActivityThread.java:5345)
D/ERROR   ( 1993):      at java.lang.reflect.Method.invoke(Native Method)
D/ERROR   ( 1993):      at java.lang.reflect.Method.invoke(Method.java:372)
D/ERROR   ( 1993):      at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:947)
D/ERROR   ( 1993):      at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:742)
```

Also the `FileOutputStream` was never closed.

## Test Plan (required)

Functionality does not change, so there is nothing more to test. It will only
- make sure that the file is actually written to disk
- the image is not duplicated in memory

