### PR TITLE
refactor permission location

### DIFF
--- a/Example/android/app/src/main/AndroidManifest.xml
+++ b/Example/android/app/src/main/AndroidManifest.xml
@@ -2,8 +2,6 @@
     package="com.example">
 
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.CAMERA" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-feature android:name="android.hardware.camera" android:required="false"/>
     <uses-feature android:name="android.hardware.camera.autofocus" />
 

--- a/README.md
+++ b/README.md
@@ -71,13 +71,7 @@ IMPORTANT NOTE: You'll still need to perform step 4 for iOS and steps 2, 3, and 
     }
     ```
     
-5. Add the required permissions in `AndroidManifest.xml`:
-    ```xml
-    <uses-permission android:name="android.permission.CAMERA" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
-    ```
-    
-6. Add the import and link the package in `MainApplication.java`:
+5. Add the import and link the package in `MainApplication.java`:
     ```java
     import com.imagepicker.ImagePickerPackage; // <-- add this import
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -3,6 +3,8 @@
   xmlns:android="http://schemas.android.com/apk/res/android"
   package="com.imagepicker"
   >
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <application>
       <provider
             android:name="android.support.v4.content.FileProvider"


### PR DESCRIPTION
Motivation: Permission used by library should be declared in library manifest. It will be automatically merged to the final file.