### PR TITLE
programmatically grant permission

### DIFF
--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -540,8 +540,10 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
                                    @NonNull final Callback callback,
                                    @NonNull final int requestCode)
   {
-    final int writePermission = ActivityCompat
-            .checkSelfPermission(activity, Manifest.permission.WRITE_EXTERNAL_STORAGE);
+    final int writePermission = Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT ?
+                                PackageManager.PERMISSION_GRANTED :
+                                ActivityCompat.checkSelfPermission(activity, Manifest.permission.WRITE_EXTERNAL_STORAGE);
+
     final int cameraPermission = ActivityCompat
             .checkSelfPermission(activity, Manifest.permission.CAMERA);
 


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [ ] Explain the **motivation** for making this change.
- [ ] Provide a **test plan** demonstrating that the code is solid.
- [ ] Match the **code formatting** of the rest of the codebase.
- [ ] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)

What existing problem does the pull request solve?
This is a temporary, naive solution to the issue where we're getting `WRITE_EXTERNAL_STORAGE` permission denied despite having necessary permissions in android manifest. noted that for api versions >= 19, it's not necessary to request permission for `WRITE_EXTERNAL_STORAGE` given use of what's returned by getExternalFilesDir(String) and getExternalCacheDir().

## Test Plan (required)

Again, not expecting this to merge. this is more to spur discussion. and a quick fix for me before the holiday.

