### PR TITLE
depend on PermissionAwareActivity rather than ReactActivity

### DIFF
--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -23,7 +23,6 @@ import android.util.Patterns;
 import android.webkit.MimeTypeMap;
 import android.content.pm.PackageManager;
 
-import com.facebook.react.ReactActivity;
 import com.facebook.react.bridge.ActivityEventListener;
 import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -49,6 +48,7 @@ import java.lang.ref.WeakReference;
 import java.util.List;
 
 import com.facebook.react.modules.core.PermissionListener;
+import com.facebook.react.modules.core.PermissionAwareActivity;
 
 import static com.imagepicker.utils.MediaUtils.*;
 import static com.imagepicker.utils.MediaUtils.createNewFile;
@@ -597,9 +597,9 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
       else
       {
         String[] PERMISSIONS = {Manifest.permission.WRITE_EXTERNAL_STORAGE, Manifest.permission.CAMERA};
-        if (activity instanceof ReactActivity)
+        if (activity instanceof PermissionAwareActivity)
         {
-          ((ReactActivity) activity).requestPermissions(PERMISSIONS, requestCode, listener);
+          ((PermissionAwareActivity) activity).requestPermissions(PERMISSIONS, requestCode, listener);
         }
         else if (activity instanceof OnImagePickerPermissionsCallback)
         {


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

## Motivation (required)
react-native-image-picker is incompatible with e.g. wix/react-native-navigation, since NavigationActivity implements PermissionAwareActivity rather than extending ReactActivity. 

## Test Plan (required)
Not really sure.. I guess no further testing should be necessary !?
