### PR TITLE
Set this.callback before permissionsCheck so that permissionDenied dialog doesn't crash when trying to call the callback

### DIFF
--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -223,6 +223,7 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
       return;
     }
 
+    this.callback = callback;
     this.options = options;
 
     if (!permissionsCheck(currentActivity, callback, REQUEST_PERMISSIONS_FOR_CAMERA))
@@ -273,8 +274,6 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
       return;
     }
 
-    this.callback = callback;
-
     // Workaround for Android bug.
     // grantUriPermission also needed for KITKAT,
     // see https://code.google.com/p/android/issues/detail?id=76683
@@ -311,6 +310,7 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
       return;
     }
 
+    this.callback = callback;
     this.options = options;
 
     if (!permissionsCheck(currentActivity, callback, REQUEST_PERMISSIONS_FOR_LIBRARY))
@@ -340,8 +340,6 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
       responseHelper.invokeError(callback, "Cannot launch photo library");
       return;
     }
-
-    this.callback = callback;
 
     try
     {


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)

Fix a crash when launching either `launchCamera` or `launchImageLibrary` directly after having denied permissions and hitting OK on permissionDenied dialog. 

## Test Plan (required)

- Launch picker using `launchImageLibrary`
- Deny permissions
- Relaunch using `launchImageLibrary` with `permissionDenied` options specified
- Hit "I'm sure" button on permissionDenied dialog (or whatever text it was configured for)

Expected: dialog closes
Actual: crash due to missing callback
