### PR TITLE
[iOS] Fix Xcode value conversion warnings

### DIFF
--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -313,8 +313,9 @@ RCT_EXPORT_METHOD(showImagePicker:(NSDictionary *)options callback:(RCTResponseS
                 ALAssetsLibrary* assetsLibrary = [[ALAssetsLibrary alloc] init];
                 [assetsLibrary assetForURL:imageURL resultBlock:^(ALAsset *asset) {
                     ALAssetRepresentation *rep = [asset defaultRepresentation];
-                    Byte *buffer = (Byte*)malloc(rep.size);
-                    NSUInteger buffered = [rep getBytes:buffer fromOffset:0.0 length:rep.size error:nil];
+                    const NSUInteger repSize = (NSUInteger)[rep size];
+                    Byte *buffer = (Byte*)malloc(repSize);
+                    NSUInteger buffered = [rep getBytes:buffer fromOffset:0.0 length:repSize error:nil];
                     NSData *data = [NSData dataWithBytesNoCopy:buffer length:buffered freeWhenDone:YES];
                     [data writeToFile:path atomically:YES];
 
@@ -682,7 +683,7 @@ RCT_EXPORT_METHOD(showImagePicker:(NSDictionary *)options callback:(RCTResponseS
     }
     else {
         NSLog(@"Error setting skip backup attribute: file not found");
-        return @NO;
+        return NO;
     }
 }
 


### PR DESCRIPTION
- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)

This fixes warnings that appear when targeting 32-bit architectures (iPhone 4S for example), the warnings are as follows:

<img width="323" alt="screen shot 2018-03-25 at 6 11 36 pm" src="https://user-images.githubusercontent.com/3321592/37880587-0a51fc20-3059-11e8-9a0d-f2f0e1c5b384.png">

1. `Implicit conversion loses integer precision: 'long long' to 'unsigned long'` (2 occurrences)
    - `malloc` expects an `unsigned long`. `NSUInteger` in 32-bit architectures is an `unsigned long` where in 64-bit it is a `unsigned int`, it makes more sense to cast to `NSUInteger` explicitly.
2. `Implicit pointer to integer conversion returning 'NSNumber *' from a function with result type 'BOOL' (aka 'signed char')` (1 occurrence)
    - This could introduce subtle bugs if any method depends on this result since we're casting an object to a BOOL. This will perform an existence check and `@NO` is an NSNumber object that is not nil so it'll always return `YES`.
    - This was also reported in #783 

## Test Plan (required)

### Scenario 1 (corresponds to point 1 above)

Pre-requisite: Find a GIF online and save it to Photos
1. Launch image picker via `Select a Photo` and tap `Choose from Library...`
2. Select the GIF that you downloaded earlier
3. Verify that it resizes correctly

### Scenario 2

This one is a bit more complicated to test for the following reasons:
- The returned `BOOL` from the `addSkipBackupAttributeToItemAtPath:` method is unused
- There is a direct coupling with the `[NSFileManager defaultManager]` singleton so we would need to refactor this and allow for dependency injection so we can mock the file manager and have a proper test for this
 