### PR TITLE
since Android6.0, start to request permission, and fail to open camera

### DIFF
--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -223,6 +223,7 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
       return;
     }
 
+    this.callback = callback;
     this.options = options;
 
     if (!permissionsCheck(currentActivity, callback, REQUEST_PERMISSIONS_FOR_CAMERA))
@@ -311,6 +312,7 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
       return;
     }
 
+    this.callback = callback;
     this.options = options;
 
     if (!permissionsCheck(currentActivity, callback, REQUEST_PERMISSIONS_FOR_LIBRARY))


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)

On BTV-W09(HUAWEI)  Android 7.0 device, I only use ReactMethods(launchImageLibrary、launchCamera), start to request camera permission, and have camera permission, at last when exec listener callback,it doesn't do private methods，due to this.callback is null.

## Test Plan (required)

###Scenario 1
On BTV-W09(HUAWEI)  Android 7.0 device don't authorize camera permission

1. In js code ,ImagePicker.launchCamera(options, (response) => {});
2. start to request camera permission;
3. agree to get camera permission;
4. don't open camera;

###Scenario 2
On BTV-W09(HUAWEI)  Android 7.0 device have authorized camera permission
1. In js code ,ImagePicker.launchCamera(options, (response) => {});
2. open camera;
