### PR TITLE
Add declaration for default export

### DIFF
--- a/index.js.flow
+++ b/index.js.flow
@@ -58,3 +58,9 @@ declare export function launchCamera(callback: (response: Response) => any): voi
 
 declare export function launchImageLibrary(options: ?Options, callback: (response: Response) => any): void;
 declare export function launchImageLibrary(callback: (response: Response) => any): void;
+
+declare export default {
+  showImagePicker(options: ?Options, callback: (response: Response) => any): void
+  launchCamera(options: ?Options, callback: (response: Response) => any): void,
+  launchImageLibrary(callback: (response: Response) => any): void,
+};


### PR DESCRIPTION
## Motivation

When importing this module (ES6) the following Flow error is thrown.

> Cannot import a default export because there is no default export in `react-native-image-picker`.

```js
import ImagePicker from "react-native-image-picker";
```

## Test Plan

To test this is working and replicate, please install the [Atom IDE](https://ide.atom.io/) with the [ide-flowtype](https://github.com/flowtype/ide-flowtype) extension.

If you create a file, `index.js` for example and add the following code.

```js
// @flow
import ImagePicker from "react-native-image-picker";
```

## Caveats

This however this doesn’t account for how the functions above are declared twice with different arguments. I’m not sure how to best go about this though...

```jsx
declare export function launchImageLibrary(options: ?Options, callback: (response: Response) => any): void;
declare export function launchImageLibrary(callback: (response: Response) => any): void;
```