### PR TITLE
Version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-image-picker",
   "description": "A React Native module that allows you to use native UI to select media from the device library or directly from the camera",
-  "version": "0.26.7",
+  "version": "0.26.10",
   "main": "index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Version 0.26.10 was released to NPM.  The `package.json` file version should match.
 
 A git tag for `v0.26.10` should also be attached to this version bump commit after merging.