### PR TITLE
allows  for projects to override build script versions

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,6 +7,14 @@ def computeVersionName() {
     return json.version
 }
 
+def _ext = rootProject.ext
+
+def _reactNativeVersion = _ext.has('reactNative') ? _ext.reactNative : '+'
+def _compileSdkVersion = _ext.has('compileSdkVersion') ? _ext.compileSdkVersion : 25
+def _buildToolsVersion = _ext.has('buildToolsVersion') ? _ext.buildToolsVersion : '25.0.2'
+def _minSdkVersion = _ext.has('minSdkVersion') ? _ext.minSdkVersion : 16
+def _targetSdkVersion = _ext.has('targetSdkVersion') ? _ext.targetSdkVersion : 25
+
 buildscript {
     repositories {
         jcenter()
@@ -20,12 +28,12 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion _compileSdkVersion
+    buildToolsVersion _buildToolsVersion
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 25
+        minSdkVersion _minSdkVersion
+        targetSdkVersion _targetSdkVersion
         versionCode 1
         versionName computeVersionName()
     }
@@ -45,7 +53,7 @@ repositories {
 }
 
 dependencies {
-    compile "com.facebook.react:react-native:+"  // From node_modules
+    compile "com.facebook.react:react-native:${_reactNativeVersion}"  // From node_modules
     
     testCompile "junit:junit:4.10"
     testCompile "org.assertj:assertj-core:1.7.0"


### PR DESCRIPTION
## Motivation 

Currently, there is no way to specify the buildToolsVersion, compileSdkVersion, reactNativeVersion,  targetSdkVersion, and minimumSdkVersion. For projects that target api 27 or later, this produces warnings of multiple api's being used.  This PR utilizes the defaults already inside the `build.gradle` when not specified.

## Test Plan (required)

An example of overriding default version, to be placed inside the project's build.gradle
```
allProjects{
  project.ext {
     compileSdkVersion=27
     targetSdkVersion=27
     buildToolsVersion='27.0.3'
     minSdkVersion='21'
  }
}
```