### PR TITLE
Update build.gradle to support ReactNative v56 build

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -19,13 +19,20 @@ buildscript {
 
 apply plugin: 'com.android.library'
 
+def _ext = rootProject.ext;
+
+def _compileSdkVersion = _ext.has('compileSdkVersion') ? _ext.compileSdkVersion : 25;
+def _buildToolsVersion = _ext.has('buildToolsVersion') ? _ext.buildToolsVersion : '25.0.2';
+def _minSdkVersion = _ext.has('minSdkVersion') ? _ext.minSdkVersion : 16;
+def _targetSdkVersion = _ext.has('targetSdkVersion') ? _ext.targetSdkVersion : 25;
+
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion _compileSdkVersion
+    buildToolsVersion _buildToolsVersion
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 25
+        minSdkVersion _minSdkVersion
+        targetSdkVersion _targetSdkVersion
         versionCode 1
         versionName computeVersionName()
     }


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [ ] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)

What existing problem does the pull request solve?

Current library is not compatible to RN v56. Other work arounds posted in https://github.com/react-community/react-native-image-picker/issues/882 it messes up with other libraries from my testing. I feel like this PR should be the correct solution.

## Test Plan (required)

After these changes I was able to build my application without getting any error after upgrading to RN v56. https://github.com/react-community/react-native-image-picker/issues/882

Please let me know if there is anything needed to verify this.