### PR TITLE
Fix runtime crashe for Android 7.

### DIFF
--- a/android/src/main/java/com/imagepicker/media/ImageConfig.java
+++ b/android/src/main/java/com/imagepicker/media/ImageConfig.java
@@ -107,12 +107,12 @@ public class ImageConfig
         int maxWidth = 0;
         if (options.hasKey("maxWidth"))
         {
-            maxWidth = options.getInt("maxWidth");
+            maxWidth = (int) options.getDouble("maxWidth");
         }
         int maxHeight = 0;
         if (options.hasKey("maxHeight"))
         {
-            maxHeight = options.getInt("maxHeight");
+            maxHeight = (int) options.getDouble("maxHeight");
         }
         int quality = 100;
         if (options.hasKey("quality"))
@@ -122,7 +122,7 @@ public class ImageConfig
         int rotation = 0;
         if (options.hasKey("rotation"))
         {
-            rotation = options.getInt("rotation");
+            rotation = (int) options.getDouble("rotation");
         }
         boolean saveToCameraRoll = false;
         if (options.hasKey("storageOptions"))


### PR DESCRIPTION
## Steps to reproduce
call: ImagePicker.launchCamera for an Android 7 device.

## Expected  behavior
camera launches succcessfully.

## Actual behavior
Crash message:
        Tried to read an int but got non-integral double.

[1]: https://medium.com/@martinkonicek/what-is-a-test-plan-8bfc840ec171#.y9lcuqqi9
![error](https://user-images.githubusercontent.com/7831340/44721446-9c7b9900-aad2-11e8-985f-b1cc1b1a18e9.png)