### PR TITLE
Add license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,5 +34,6 @@
   "scripts": {
     "prepare": "rm -rf android/build Example/android/build Example/android/app/build node_modules"
   },
-  "types": "./index.d.ts"
+  "types": "./index.d.ts",
+  "license": "MIT"
 }


### PR DESCRIPTION
Hello - I noticed that NPM does not list a license for this project because a "license" is not specified in package.json. This PR fixes this omission.