### PR TITLE
Fix root path exception for older Android devices

### DIFF
--- a/android/src/main/res/xml/provider_paths.xml
+++ b/android/src/main/res/xml/provider_paths.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths xmlns:android="http://schemas.android.com/apk/res/android">
     <external-path name="app_images" path="."/>
+    <external-files-path name="app_images" path="Pictures" />
 </paths>


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid. **N/A**
- [x] Match the **code formatting** of the rest of the codebase. **N/A**
- [x] Target the `master` branch, NOT a "stable" branch. **Yes**

## Motivation (required)
To fix root path exception thrown on older Android devices:
https://stackoverflow.com/questions/42407486/java-lang-illegalargumentexception-failed-to-find-configured-root-that-contains

## Test Plan (required)
**N/A** I know of no good way to write an automated test for this. If you need to see this in action simply attempt to take a picture using the latest from `master` on Android 7.0 or earlier (support library v4). It will crash with the exception listed above. After applying this patch and rebuilding it no longer has an issue.
