### PR TITLE
Add note for NSCameraUsageDescription

### DIFF
--- a/docs/Install.md
+++ b/docs/Install.md
@@ -33,6 +33,15 @@ Add the `NSPhotoLibraryUsageDescription`, `NSCameraUsageDescription`, `NSPhotoLi
 </plist>
 ```
 
+⚠️ If you are planning on submitting your application to app store:
+
+To be compliant with Guideline 5.1.1 - Legal - Privacy - Data Collection and Storage, the permission request alert should specify how your app will use this feature to help users understand why your app is requesting access to their personal data.
+
+```
+$(PRODUCT_NAME) would like access to your photo gallery to change your profile picture
+```
+
+
 ### Android
 
 Add the required permissions in `AndroidManifest.xml`:


### PR DESCRIPTION
Used the example in the install.md but got rejected in app store due to Guideline 5.1.1 - Legal - Privacy - Data Collection and Storage.

The permission request alert should specify how your app will use this feature to help users understand why your app is requesting access to their personal data.

To hinder other people from getting their binary rejected, a note has been added to this section.

*What existing problem does the pull request solve?*
The pull request solves the problem of binaries getting rejected in app store due to not specifying how the app will use their personal data.
